### PR TITLE
Change open-source section wording.

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
         <div style="text-align: right; color: #aaaaaa;">
           Quark Editor is made by <a href="https://sheshank.com">Sheshank Shankar</a> &copy; 2018
           <br />
-          Our <i class="fa fa-code" aria-hidden="true"></i> is open-source. View <a href="https://github.com/GreenBayRules/quark-editor">here</a>.
+          Our <i class="fa fa-code" aria-hidden="true"></i> is open-source. View it <a href="https://github.com/GreenBayRules/quark-editor">here</a>.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Just a minor change.

Currently, in the settings, it mentions:
![1](https://user-images.githubusercontent.com/26391179/39409096-ef5b694c-4bd8-11e8-82fb-6df46a17f600.png)

I thought it would make more sense it said:
![2](https://user-images.githubusercontent.com/26391179/39409116-252804e0-4bd9-11e8-93a8-88f8d1770f9e.png)

So I've made that small change. What do you think?